### PR TITLE
Add support for injecting locals from config settings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,27 @@
 ## Requirement
 
 * [source-preview](https://atom.io/packages/source-preview)
+
+## Atom Settings
+
+Modify your `config.cson` to support rendering templates that use locals.
+
+`config.cson`
+```cson
+"source-preview-pug":
+    useDefaultLocals: true
+    defaultLocals:
+        localValue: "Test"
+```
+
+`template.jade`
+```jade
+p The local is: #{localValue}.
+```
+
+`compiled.html`
+```html
+<p>The local is: Test</p>
+```
+
+The package [`local-settings`](https://atom.io/packages/local-settings) can help by providing project-level configuration settings for your atom editor.

--- a/lib/jade-provider.coffee
+++ b/lib/jade-provider.coffee
@@ -1,4 +1,4 @@
-[loophole, jade] = []
+[loophole, jade, objectAssign] = []
 
 module.exports =
 class JadeProvider
@@ -7,10 +7,16 @@ class JadeProvider
 
   transform: (code, {filePath} = {}) ->
     jade ?= @unsafe -> require 'jade'
+    objectAssign ?= @unsafe -> require 'object-assign'
 
     options =
       pretty: true
       filename: filePath
+
+    if atom.config.get('source-preview-pug.useDefaultLocals')
+      locals = atom.config.get('source-preview-pug.defaultLocals');
+      if locals
+          objectAssign(options, locals);
 
     {
       code: @unsafe -> jade.render(code, options)

--- a/lib/pug-provider.coffee
+++ b/lib/pug-provider.coffee
@@ -1,4 +1,4 @@
-[loophole, pug] = []
+[loophole, pug, objectAssign] = []
 
 module.exports =
 class PugProvider
@@ -7,10 +7,16 @@ class PugProvider
 
   transform: (code, {filePath} = {}) ->
     pug ?= @unsafe -> require 'pug'
+    objectAssign ?= @unsafe -> require 'object-assign'
 
     options =
       pretty: true
       filename: filePath
+
+    if atom.config.get('source-preview-pug.useDefaultLocals')
+      locals = atom.config.get('source-preview-pug.defaultLocals');
+      if locals
+        objectAssign(options, locals);
 
     {
       code: @unsafe -> pug.render(code, options)


### PR DESCRIPTION
This adds support for injecting locals through atom configuration settings.
## Configuration

This adds two keys to the configuration settings for source-preview-pug:
### useDefaultLocals

`Boolean` - When true, injects the values in the `defaultLocals` key as locals when rendering the source.
### defaultLocals

`Object` - Each nested key is added as a local to the rendering context.

This allows the package to be able to render files that include locals, where previously an error would be thrown and rendering would fail.

Fixes #4 
